### PR TITLE
fix: refresh account balance

### DIFF
--- a/packages/wallet_kit/lib/widgets/account_balance_refresher.dart
+++ b/packages/wallet_kit/lib/widgets/account_balance_refresher.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import '../wallet_state/index.dart';
+
+class AccountBalanceRefresher extends HookConsumerWidget {
+  const AccountBalanceRefresher({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedAccount = ref.watch(walletsProvider.select((value) => value.selectedAccount));
+    useEffect(() {
+      if (selectedAccount != null) {
+        ref.read(walletsProvider.notifier)
+          ..refreshEthBalance(selectedAccount.walletId, selectedAccount.id)
+          ..refreshStrkBalance(selectedAccount.walletId, selectedAccount.id);
+      }
+      return null;
+    }, [selectedAccount?.id]);
+    return const SizedBox.shrink();
+  }
+} 

--- a/packages/wallet_kit/lib/widgets/account_balance_refresher.dart
+++ b/packages/wallet_kit/lib/widgets/account_balance_refresher.dart
@@ -8,7 +8,8 @@ class AccountBalanceRefresher extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final selectedAccount = ref.watch(walletsProvider.select((value) => value.selectedAccount));
+    final selectedAccount =
+        ref.watch(walletsProvider.select((value) => value.selectedAccount));
     useEffect(() {
       if (selectedAccount != null) {
         ref.read(walletsProvider.notifier)
@@ -19,4 +20,4 @@ class AccountBalanceRefresher extends HookConsumerWidget {
     }, [selectedAccount?.id]);
     return const SizedBox.shrink();
   }
-} 
+}

--- a/packages/wallet_kit/lib/widgets/wallet_body.dart
+++ b/packages/wallet_kit/lib/widgets/wallet_body.dart
@@ -6,6 +6,7 @@ import '../wallet_state/index.dart';
 import 'nft_details.dart';
 import 'nft_list.dart';
 import 'token_list.dart';
+import 'account_balance_refresher.dart';
 
 class WalletBody extends HookConsumerWidget {
   const WalletBody({super.key});
@@ -20,10 +21,12 @@ class WalletBody extends HookConsumerWidget {
         child: Text('No account selected.'),
       );
     }
+    final refresher = const AccountBalanceRefresher();
     return Expanded(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
+          refresher,
           TabBar.secondary(
             controller: tabController,
             tabs: const <Widget>[

--- a/packages/wallet_kit/lib/widgets/wallet_body.dart
+++ b/packages/wallet_kit/lib/widgets/wallet_body.dart
@@ -21,7 +21,7 @@ class WalletBody extends HookConsumerWidget {
         child: Text('No account selected.'),
       );
     }
-    const refresher = const AccountBalanceRefresher();
+    const refresher = AccountBalanceRefresher();
     return Expanded(
       child: Column(
         mainAxisSize: MainAxisSize.min,

--- a/packages/wallet_kit/lib/widgets/wallet_body.dart
+++ b/packages/wallet_kit/lib/widgets/wallet_body.dart
@@ -21,7 +21,7 @@ class WalletBody extends HookConsumerWidget {
         child: Text('No account selected.'),
       );
     }
-    final refresher = const AccountBalanceRefresher();
+    const refresher = const AccountBalanceRefresher();
     return Expanded(
       child: Column(
         mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
**Summary of the changes:**

- A new widget, `AccountBalanceRefresher`, was created. This widget listens for changes to the selected account and automatically refreshes the ETH and STRK balances whenever the selected account changes.
- `AccountBalanceRefresher` was added at the top of the `WalletBody` widget tree, ensuring it is always active when a wallet is displayed.

**Why this works:**

Previously, balance refresh logic was only triggered by certain widgets (like `TokenList` inside `WalletBody`). If those widgets were not present, balances would not update, causing components like `DeployAccountButton` to show "Not enough ETH" even when the account had ETH.

By introducing `AccountBalanceRefresher` and placing it in `WalletBody`, the app now always refreshes balances for the selected account, regardless of the widget tree structure. This ensures that all widgets relying on up-to-date balances (such as `DeployAccountButton`) work correctly in any layout.

- Closes #523 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic background refreshing of Ethereum and Strk account balances when switching accounts in the wallet interface. This occurs seamlessly without displaying additional UI elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->